### PR TITLE
Fixes and small things

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 	modImplementation "com.terraformersmc:modmenu:${project.mod_menu_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 
 	// https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit used pull data from the NEU item repo
 	include(implementation("org.eclipse.jgit:org.eclipse.jgit:6.4.0.202211300538-r"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ yarn_mappings=1.19.4+build.1
 loader_version=0.14.18
 
 #Fabric api
-## 1.19.3
-fabric_version=0.76.0+1.19.4
+## 1.19.4
+fabric_api_version=0.76.0+1.19.4
 
 # Dependencies
 ## Cloth Api (https://www.curseforge.com/minecraft/mc-mods/cloth-config/files)

--- a/src/main/java/me/xmrvizzy/skyblocker/mixin/ItemRendererMixin.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/mixin/ItemRendererMixin.java
@@ -1,6 +1,16 @@
 package me.xmrvizzy.skyblocker.mixin;
 
+import java.awt.Color;
+import java.util.regex.Pattern;
+
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
 import com.mojang.blaze3d.systems.RenderSystem;
+
 import me.xmrvizzy.skyblocker.config.SkyblockerConfig;
 import me.xmrvizzy.skyblocker.utils.ItemUtils;
 import me.xmrvizzy.skyblocker.utils.Utils;
@@ -10,14 +20,7 @@ import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.util.math.MathHelper;
-import org.jetbrains.annotations.Nullable;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.regex.Pattern;
+import net.minecraft.util.math.ColorHelper;
 
 @Mixin(ItemRenderer.class)
 public abstract class ItemRendererMixin {
@@ -43,13 +46,11 @@ public abstract class ItemRendererMixin {
                         }
 
                         RenderSystem.disableDepthTest();
-                        RenderSystem.disableBlend();
                         float hue = Math.max(0.0F, 1.0F - (max - current) / max);
                         int width = Math.round(current / max * 13.0F);
-                        int rgb = MathHelper.hsvToRgb(hue / 3.0F, 1.0F, 1.0F);
+                        Color colour = Color.getHSBColor(hue / 3.0F, 1.0F, 1.0F);
                         DrawableHelper.fill(matrices, x + 2, y + 13, x + 15, y + 15, 0xFF000000);
-                        DrawableHelper.fill(matrices, x + 2, y + 13, x + 2 + width, y + 14, rgb);
-                        RenderSystem.enableBlend();
+                        DrawableHelper.fill(matrices, x + 2, y + 13, x + 2 + width, y + 14, ColorHelper.Argb.getArgb(colour.getAlpha(), colour.getRed(), colour.getGreen(), colour.getBlue()));
                         RenderSystem.enableDepthTest();
                     }
                 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,10 +26,10 @@
     "skyblocker.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.6",
-    "fabric": "*",
+    "fabricloader": ">=0.14.17",
+    "fabric-api": ">=0.76.0+1.19.4",
     "cloth-config2": "*",
-    "minecraft": ["1.19.4"]
+    "minecraft": ">=1.19.4"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
• Fixed the Drill Fuel colour not being in ARGB format
• Removed enable/disable blend calls since they're no longer necessary
• Require Loader 0.14.17+ since older versions don't work with 1.19.4
• Updated Fabric API mod id (old one will probably stop working later on)
• More inclusive mc version requirement (who knows maybe the 1.19.4 builds will work with 1.20)